### PR TITLE
Add --execution-limit to test varied lambda handler deadlines

### DIFF
--- a/awslambdarpc.go
+++ b/awslambdarpc.go
@@ -18,6 +18,8 @@ Available options:
 		path to the event JSON to be used as input
 	-d, --data
 		data passed to the function as input, in JSON format, defaults to "{}"
+	-l, --execution-limit
+		maximum execution limit for your handler, expressed as a duration, defaults to 15s
 	help, -h, --help
 		show this help
 
@@ -35,7 +37,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/aws/aws-lambda-go/lambda/messages"
 	"github.com/blmayer/awslambdarpc/client"
 )
 
@@ -96,7 +97,7 @@ func main() {
 		case "-d", "--data":
 			i++
 			payload = []byte(os.Args[i])
-		case "--execution-limit":
+		case "-l", "--execution-limit":
 			i++
 			duration, err := time.ParseDuration(os.Args[i])
 			if err != nil {
@@ -114,11 +115,7 @@ func main() {
 		}
 	}
 
-	deadline := time.Now().Add(executionLimit)
-	res, err := client.Invoke(addr, payload, messages.InvokeRequest_Timestamp{
-		Seconds: deadline.Unix(),
-		Nanos:   int64(deadline.Nanosecond()),
-	})
+	res, err := client.Invoke(addr, payload, executionLimit)
 	if err != nil {
 		os.Stderr.WriteString(err.Error() + "\n")
 		os.Exit(-2)

--- a/client/rpc.go
+++ b/client/rpc.go
@@ -15,8 +15,8 @@ import (
 // to the lambda function as body.
 // If the lambda returned an error then this function will return
 // the error message in the error interface
-func Invoke(addr string, data []byte) ([]byte, error) {
-	request := messages.InvokeRequest{Payload: data}
+func Invoke(addr string, data []byte, deadline messages.InvokeRequest_Timestamp) ([]byte, error) {
+	request := messages.InvokeRequest{Payload: data, Deadline: deadline}
 	client, err := rpc.Dial("tcp", addr)
 	if err != nil {
 		return nil, err

--- a/client/rpc.go
+++ b/client/rpc.go
@@ -5,6 +5,7 @@ package client
 import (
 	"fmt"
 	"net/rpc"
+	"time"
 
 	"github.com/aws/aws-lambda-go/lambda/messages"
 )
@@ -15,8 +16,12 @@ import (
 // to the lambda function as body.
 // If the lambda returned an error then this function will return
 // the error message in the error interface
-func Invoke(addr string, data []byte, deadline messages.InvokeRequest_Timestamp) ([]byte, error) {
-	request := messages.InvokeRequest{Payload: data, Deadline: deadline}
+func Invoke(addr string, data []byte, executionLimit time.Duration) ([]byte, error) {
+	deadline := time.Now().Add(executionLimit)
+	request := messages.InvokeRequest{Payload: data, Deadline: messages.InvokeRequest_Timestamp{
+		Seconds: deadline.Unix(),
+		Nanos:   int64(deadline.Nanosecond()),
+	}}
 	client, err := rpc.Dial("tcp", addr)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
In addition to resolving [this issue](https://www.repost.aws/questions/QUcheUbOSJS-yWBxbXh5D1tw/aws-sdk-go-v2-lambda-deadline-is-1970-01-1-while-local-debugging) that's being discussed, it will allow lambda authors to simulate and test varied execution limits in their lambda handlers. In the current form, it's defaulting to a 15 second execution limit, by default. Given that it's currently failing w/ a Deadline equivalent to the beginning of the unix epoch, it seemed safe enough to add a default, rather than forcing the caller to always specify an execution limit.